### PR TITLE
Upload assets on release

### DIFF
--- a/.github/workflows/upload-assets-when-release-published.yml
+++ b/.github/workflows/upload-assets-when-release-published.yml
@@ -1,0 +1,130 @@
+name: Upload assets when release published
+on:
+  release:
+    types: [published]
+jobs:
+  version:
+    name: Create version number
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Fetch all history for all tags and branches
+        run: |
+          git config remote.origin.url https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
+          git fetch --prune --depth=10000
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.10
+        with:
+          versionSpec: '5.x'
+      - name: Use GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.10
+      - name: Create version.txt with nuGetVersion
+        run: echo ${{ steps.gitversion.outputs.nuGetVersion  }} > version.txt
+      - name: Upload version.txt
+        uses: actions/upload-artifact@v2
+        with:
+          name: gitversion
+          path: version.txt
+  build:
+    name: Build APK and AppBundle
+    runs-on: ubuntu-latest
+    needs: [ version ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get version.txt
+        uses: actions/download-artifact@v2
+        with:
+          name: gitversion
+      - name: Create new file without newline char from version.txt
+        run: tr -d '\n' < version.txt > version1.txt
+      - name: Read version
+        id: version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: version1.txt
+      - name: Update version in YAML
+        run: sed -i 's/99.99.99+99/${{ steps.version.outputs.content }}+${{ github.run_number }}/g' pubspec.yaml
+      - name: Set up Java
+        uses: actions/setup-java@v2.1.0
+        with:
+          distribution: 'adopt' # See 'Supported distributions' for available options
+          java-version: '15.x'
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v1
+        with:
+          channel: 'stable' # or: 'beta', 'dev' or 'master'
+      - name: Create upload-keystore.jks
+        id: write_file
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'upload-keystore.jks'
+          encodedString: ${{ secrets.KEYSTORE }}
+      - name: Create key.properties
+        run: |
+          echo "storePassword=$store_password" >> android/key.properties
+          echo "keyPassword=$key_password" >> android/key.properties
+          echo "keyAlias=upload" >> android/key.properties
+          echo "storeFile=$store_file_path" >> android/key.properties
+        env:
+          store_file_path: ${{ steps.write_file.outputs.filePath }}
+          store_password: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          key_password: ${{ secrets.SIGNING_KEY_PASSWORD }}
+      - run: flutter pub get
+      - run: flutter test
+      - name: Build APK
+        run: flutter build apk --release
+      - name: Build AppBundle
+        run: flutter build appbundle --release
+        env:
+          current_tag: ${{ github.ref }}
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+      - name: Upload AppBundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: appbundle
+          path: build/app/outputs/bundle/release/app-release.aab
+  release:
+    name: Release app to Play Store, GH Release, and Heroku
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get APK from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: apk
+      - name: Get AppBundle from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: appbundle
+      - name: Add APK to release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          files: |
+            app-release.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge main branch into heroku-deploy
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: main
+          target_branch: heroku-deploy
+          github_token: ${{ github.token }}
+      - name: Upload to Google Play internal testing track
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          packageName: io.github.incplusplus.chem_catalyst
+          releaseFiles: app-release.aab
+          track: beta
+#          whatsNewDirectory: distribution/whatsnew

--- a/.github/workflows/upload-assets-when-release-published.yml
+++ b/.github/workflows/upload-assets-when-release-published.yml
@@ -120,11 +120,11 @@ jobs:
           from_branch: main
           target_branch: heroku-deploy
           github_token: ${{ github.token }}
-      - name: Upload to Google Play internal testing track
-        uses: r0adkll/upload-google-play@v1
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
-          packageName: io.github.incplusplus.chem_catalyst
-          releaseFiles: app-release.aab
-          track: beta
+#      - name: Upload to Google Play internal testing track
+#        uses: r0adkll/upload-google-play@v1
+#        with:
+#          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+#          packageName: io.github.incplusplus.chem_catalyst
+#          releaseFiles: app-release.aab
+#          track: beta
 #          whatsNewDirectory: distribution/whatsnew


### PR DESCRIPTION
The build script here does two interesting things in addition to creating and uploading assets
- Signs the Android application (following instructions from https://proandroiddev.com/how-to-securely-build-and-sign-your-android-app-with-github-actions-ad5323452ce and https://flutter.dev/docs/deployment/android#configure-signing-in-gradle)
- Sets the version number in the `pubspec.yaml` before creating release assets by reading the latest tag from git (per https://medium.com/@iqan/ci-cd-for-flutter-android-app-using-github-actions-ea065180a3be which can be found in https://github.com/iqan/flutter-ci-github-actions-demo)