### PR TITLE
Add GitVersion.yml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,3 @@
+branches:
+  master:
+    regex: ^master$|^main$


### PR DESCRIPTION
This allows workflows that use GitVersion (like the one that publishes stuff on release merged in #2) to find the main branch. See https://blogs.blackmarble.co.uk/rfennell/2020/10/14/using-gitversion-when-your-default-branch-is-not-called-master/