### PR TITLE
Add app.json to fix Heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "buildpacks": [
+    {
+      "url": "ee/heroku-buildpack-flutter-light"
+    },
+    {
+      "url": "heroku-community/static"
+    }
+  ]
+}


### PR DESCRIPTION
Review apps can only be configured _after_ creation which causes them to error out the first time unless this app.json is in the repo.